### PR TITLE
fix thumbnailer not working with thunar

### DIFF
--- a/simple-appimage-thumbnailer.sh
+++ b/simple-appimage-thumbnailer.sh
@@ -36,12 +36,11 @@ _get_diricon() (
 )
 
 _resize() {
-	convert -background none -thumbnail "$SIZE" "$TMPICON" PNG:"$TMPICON"
+	convert -background none -thumbnail "$SIZE" "$TMPICON" PNG:"$OUTPUT"
 }
 
 _sanity_check
 mkdir -p "$_TMPDIR" || _error "Could not create temp directory"
 _get_diricon || _error "Failed to extract .DirIcon, is it an AppImage?"
-_resize || _error "Failed to resize .DirIcon"
-mv -v "$TMPICON" "$OUTPUT"
+_resize || _error "Failed to resize and move .DirIcon"
 rm -rf "$_TMPDIR"


### PR DESCRIPTION
I can't believe the issue was this wtf, apparently the `mv` messes the image in a way that thunar doesn't like it???

Like the final image is the same in both cases, before I converted the image and then moved it and this worked perfectly with `pcmanfm`, `pcmanfm-qt` and `caja`. 

But with thunar you can't move the image to the destination, instead I have to tell `convert` to place the final image in the destination instead. 